### PR TITLE
Showing the branch a repository is currently on

### DIFF
--- a/clustergit
+++ b/clustergit
@@ -197,7 +197,8 @@ def check(dirname, options):
             can_push = False
             can_pull = True
             if len(options.branch) > 0 and 'On branch ' + options.branch not in out:
-                messages.append(colorize(Colors.WARNING, "Not on branch %s" % options.branch))
+                branch = out.splitlines()[0].replace("On branch ","")
+                messages.append(colorize(Colors.WARNING, "On branch %s" % branch))
                 can_pull = False
                 clean = False
             if re.search(r'nothing to commit.?.?working directory clean.?', out):


### PR DESCRIPTION
Another litle feature, hope you like it.

I work a lot with feature branches and I am very interested which branch is currently checked out. The information that a repository is not on the default branch is good, but it gives not enough information. Knowing which branch is checked out is imho even better.

Cheers,
Ben
