### PR TITLE
exclude option not working in combination with warn-unversioned

### DIFF
--- a/clustergit
+++ b/clustergit
@@ -177,6 +177,7 @@ def check(dirname, options):
 
     # See whats here
     files = os.listdir(dirname)
+    files[:] = [f for f in files if not is_excluded(os.path.join(dirname, f), options)]
     files.sort()
     for infile in files:
         infile = os.path.join(dirname, infile)
@@ -320,7 +321,6 @@ def main(args):
         dirties = 0
 
         for (path, dirs, files) in os.walk(options.dirname, topdown=True):
-            dirs[:] = [d for d in dirs if not is_excluded(os.path.join(path, d, ""), options)]
             new_gitted, new_dirties = check(path, options)
             gitted = gitted or new_gitted
             dirties += new_dirties


### PR DESCRIPTION
I have a setup like this

```
% tree
.
├── notarepo (Not a repo by accident)
├── repo1 (git repo)
├── repo2 (git repo)
└── target (build output, will never be a git repo)

4 directories, 0 files
```

I was trying to ignore the target folder with the exclude option, but it wasn't excluded. 

```
% clustergit --warn-unversioned --exclude=target
Starting git status...
Scanning sub directories of .
./notarepo                              : Not a GIT repository
./repo1                                 : Changes
./repo2                                 : Changes
./target                                : Not a GIT repository
Done
```

With this fix, exclusions work with or without --warn-unversioned

```
% clustergit --warn-unversioned --exclude=target
Starting git status...
Scanning sub directories of .
./notarepo                              : Not a GIT repository
./repo1                                 : Changes
./repo2                                 : Changes
Done
```
