### PR TITLE
Added scanning check for .clustergit-ignore

### DIFF
--- a/clustergit
+++ b/clustergit
@@ -277,6 +277,15 @@ def check(dirname, options):
     for infile in files:
         infile = os.path.join(dirname, infile)
 
+        # is there a .clustergit-ignore file
+        if os.path.exists(os.path.join(infile, ".clustergit-ignore")) :
+
+            if options.verbose:
+                print("skipping %s directory" % infile)
+
+            # Ignore this folder and continue scanning
+            continue
+
         # is there a .git file
         if os.path.exists(os.path.join(infile, ".git")):
             if options.skipSymLinks and os.path.islink(infile):


### PR DESCRIPTION
I use clustergit frequently to check the status of a hierarchy of repos so use the --recursive option pretty much all the time. I found however there were a number of folders in the hierarchy constantly popping up that I wanted to ignore.

As I am almost totally useless at generating regex's for the -e exclude flag, so I added a check for a .clustergit-ignore file that a user can touch into any directory to ignore it.

No other functionality appears to have been affected by this change, however I have only had the ability to test it on macOS with a case-insensitive file system.