### PR TITLE
Add global ignore file and optimize recursion

### DIFF
--- a/clustergit
+++ b/clustergit
@@ -277,6 +277,14 @@ def read_arguments(args):
         help="Print repository status as soon as possible not preserving order"
     )
 
+    parser.add_argument(
+        "--global-ignore-file",
+        type=str,
+        dest="global_ignore_file",
+        default="$HOME/.config/clustergit/.clustergit-ignore",
+        help="Global clustergit-ignore file"
+    )
+
     autocomplete(parser)
     options = parser.parse_args(args)
     return options
@@ -497,6 +505,7 @@ def scan(dirpath, dirnames, options) -> List[GitDir]:
 
     # Filter directories and convert to paths
     paths = [os.path.join(dirpath, dirname) for dirname in dirnames]
+
     git_dirs = [GitDir(path, options) for path in paths if dir_filter(path)]
 
     return git_dirs
@@ -554,9 +563,22 @@ def main(args):
             global colorize
             colorize = decolorize
 
+        options.global_ignore_file = os.path.expandvars(options.global_ignore_file)
+
+        if options.global_ignore_file and os.path.exists(options.global_ignore_file):
+            print('Reading global .clustergit-ignore file from {}'.format(options.global_ignore_file))
+            with open(options.global_ignore_file, 'r') as ignore_file:
+                for line in ignore_file:
+                    options.exclude.append(re.compile(line.strip()))
+
         git_dirs = []
 
-        for (path, dirs, files) in os.walk(options.dirname):
+        for (path, dirs, files) in os.walk(options.dirname, topdown=True):
+
+            # Filter dirs to prevent unnecessary recursion in subdirectories
+            if options.exclude:
+                dirs[:] = [d for d in dirs if not any([re.search(regex, os.path.join(path, d)) for regex in options.exclude])]
+
             git_dirs.extend(scan(path, dirs, options))
             if not options.recursive:
                 break


### PR DESCRIPTION
Hi! First of all, great tool! It really comes in handy to run `git status` on tens of repositories at a time.
I noticed that in some situations recursing through the folders was quite slow (e.g. because the script was going through node_modules, vendor directories), so I decided to add a global .clustergit-ignore file (with a default path in ~/.config/clustergit/.clustergit-ignore) that lists a series of regexes of directories that must always be excluded from the search.

As a second thing, I optimized the os.walk() loop by pre-filtering the `dirs` list so that the code will never go inside one of the excluded folders (rather than checking it and excluding it multiple times when looking at the files inside). 

This sped things up quite a bit for me, so I decided to open a PR.

Let me know!