### PR TITLE
Master to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ optional arguments:
                         default -- color is on by default. (default: True)
   -b BRANCH, --branch BRANCH
                         Warn if not on this branch. Set to empty string (-b
-                        '') to disable this feature. (default: master)
+                        '') to disable this feature. (default: main)
   --recursive           Recursively search for git repos (default: False)
   --skip-symlinks       Skip symbolic links when searching for git repos
                         (default: False)

--- a/clustergit
+++ b/clustergit
@@ -217,7 +217,7 @@ def read_arguments(args):
         "-b", "--branch",
         action="store",
         dest="branch",
-        default="master",
+        default="main",
         help="Warn if not on this branch. Set to empty string (-b '') to disable this feature."
     )
 


### PR DESCRIPTION
To reflect change from Oct/20 in github making main as default branch name (in place of master)