### PR TITLE
Improving line ending clearing for waiting message

### DIFF
--- a/clustergit
+++ b/clustergit
@@ -522,7 +522,7 @@ def analyze(git_dirs: List[GitDir], options):
                 # Wait for parallel execution to finish
                 for i, (future, label) in enumerate(fs.items()):
                     while not future.done():
-                        print('Waiting for %s %s (%d/%d)' % (label, next(spinner), i + 1, len(fs)), end='\r',
+                        print('Waiting for %s %s (%d/%d)' % (label, next(spinner), i + 1, len(fs)), end='\x1b[1K\r',
                               flush=True)
                         time.sleep(0.1)
                     write_with_color(sys.stdout, future.result().get_msg_buffer_as_str())


### PR DESCRIPTION
The output result for each directory was being written in such a way that extra characters from the "waiting for.." text was remaining at the end - switching to use this new `end` sequence prevents this from happening. I found this sequence at https://stackoverflow.com/a/5419488

## Before
```
$ > ./clustergit -d ~/GitHub/
Scanning sub directories of ~/GitHub/
~/GitHub/GitJournal        : Changes, Unpushed commits
~/GitHub/IPMIView.app      : Clean .   (2/32)
~/GitHub/clustergit        : Clean
~/GitHub/hammond           : Clean(9/32)
~/GitHub/foobar-examplen-plugin: Cleanlugin    . (26/32)
Done
```

## After
```
$ > ./clustergit -d ~/GitHub/
Scanning sub directories of ~/GitHub/
~/GitHub/GitJournal        : Changes, Unpushed commits
~/GitHub/IPMIView.app      : Clean
~/GitHub/clustergit        : Changes
~/GitHub/hammond           : Clean       
~/GitHub/foobar-examplen-plugin: Clean                   
Done
```