### PR TITLE
Allow regex searching for branch name (`-b` argument).

### DIFF
--- a/clustergit
+++ b/clustergit
@@ -217,8 +217,8 @@ def read_arguments(args):
         "-b", "--branch",
         action="store",
         dest="branch",
-        default="master",
-        help="Warn if not on this branch. Set to empty string (-b '') to disable this feature."
+        default="(master|main)",
+        help="Warn if not on a branch matching this Regex. Set to empty string (-b '') to disable this feature."
     )
 
     parser.add_argument(
@@ -319,7 +319,7 @@ class GitDir:
         clean = True
         can_push = False
         can_pull = True
-        if len(options.branch) > 0 and 'On branch ' + options.branch not in out:
+        if (len(options.branch) > 0 and not re.search(fr'On branch {options.branch}', out)):
             branch = out.splitlines()[0].replace("On branch ", "")
             messages.append(colorize(Colors.WARNING, "On branch %s" % branch))
             can_pull = False
@@ -377,7 +377,7 @@ class GitDir:
                     messages.append(colorize(Colors.OKGREEN, "Pulled nothing"))
             elif "CONFLICT" in pull:
                 messages.append(colorize(Colors.FAIL, "Pull conflict"))
-            elif "fatal: No remote repository specified." in pull\
+            elif "fatal: No remote repository specified." in pull \
                     or "There is no tracking information for the current branch." in pull:
                 messages.append(colorize(Colors.WARNING, "Pull remote not configured"))
             elif "fatal: " in pull:


### PR DESCRIPTION
As suggested by @fpedroza in mnagel/clustergit#37 - switch the `-b` option to accept RegEx and change the default value to `(master|main)`.

### Tested locally:
```
$ > ./clustergit -d ~/GitHub/ -b 'foobar'
Scanning sub directories of /Users/ccarini/GitHub/
/Users/ccarini/GitHub/clustergit                       : On branch ChrisCarini/regexBranch, No Changes
/Users/ccarini/GitHub/crypto-to-influxdb               : On branch main, No Changes
/Users/ccarini/GitHub/jetbrains-auto-power-saver       : On branch master, No Changes
/Users/ccarini/GitHub/jetbrains-ide-release-dates      : On branch main, No Changes
/Users/ccarini/GitHub/logshipper-intellij-plugin       : On branch master, No Changes
Done

$ > ./clustergit -d ~/GitHub/ 
Scanning sub directories of /Users/ccarini/GitHub/
/Users/ccarini/GitHub/clustergit                       : On branch ChrisCarini/regexBranch, No Changes
/Users/ccarini/GitHub/crypto-to-influxdb               : Clean
/Users/ccarini/GitHub/jetbrains-auto-power-saver       : Clean
/Users/ccarini/GitHub/jetbrains-ide-release-dates      : Clean
/Users/ccarini/GitHub/logshipper-intellij-plugin       : Clean
Done

$ > ./clustergit -d ~/GitHub/ -b '(ChrisCarini/regexBranch|main)'
Scanning sub directories of /Users/ccarini/GitHub/
/Users/ccarini/GitHub/clustergit                       : Clean
/Users/ccarini/GitHub/crypto-to-influxdb               : Clean
/Users/ccarini/GitHub/jetbrains-auto-power-saver       : On branch master, No Changes
/Users/ccarini/GitHub/jetbrains-ide-release-dates      : Clean
/Users/ccarini/GitHub/logshipper-intellij-plugin       : On branch master, No Changes
Done
```