### PR TITLE
Adding support for multiple directory input.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ It is especially useful to run `git status` recursively on one folder.
 clustergit supports `git status`, `git pull`, `git push`, and more.
 
 ## Screenshot
-![clustergit screenshot](/doc/clustergit.png?raw=true "clustergit screenshot")
+![clustergit screenshot](doc/clustergit.png?raw=true "clustergit screenshot")
 
 To reproduce the above locally, run:
 

--- a/clustergit
+++ b/clustergit
@@ -102,9 +102,11 @@ def read_arguments(args):
     parser.add_argument(
         "-d", "--dir",
         dest="dirname",
-        action="store",
+        # Action=append allows the caller to specify `-d` multiple times.
+        # For example: `-d foo -d bar/batz/git_repos` would process both directories.
+        action="append",
         help="The directory to parse sub dirs from",
-        default="."
+        default=[]
     )
 
     parser.add_argument(
@@ -546,6 +548,11 @@ def main(args):
         if options.clear:
             os.system('clear')
 
+        # If there are no dirnames set, the list will be empty;
+        # set to default value of current directory.
+        if not options.dirname:
+            options.dirname = ['.']
+
         if not options.quiet:
             print('Scanning sub directories of %s' % options.dirname)
 
@@ -556,10 +563,11 @@ def main(args):
 
         git_dirs = []
 
-        for (path, dirs, files) in os.walk(options.dirname):
-            git_dirs.extend(scan(path, dirs, options))
-            if not options.recursive:
-                break
+        for directory in options.dirname:
+            for (path, dirs, files) in os.walk(directory):
+                git_dirs.extend(scan(dirpath=path, dirnames=dirs, options=options))
+                if not options.recursive:
+                    break
 
         if len(git_dirs) == 0:
             die_with_error("None of those sub directories had a .git file")

--- a/clustergit
+++ b/clustergit
@@ -581,7 +581,7 @@ def main(args: List[str]) -> None:
         options.global_ignore_file = os.path.expandvars(options.global_ignore_file)
 
         if options.global_ignore_file and os.path.exists(options.global_ignore_file):
-            print('Reading global .clustergit-ignore file from {}'.format(options.global_ignore_file))
+            print(f'Reading global .clustergit-ignore file from {options.global_ignore_file}')
             with open(options.global_ignore_file, 'r') as ignore_file:
                 for line in ignore_file:
                     options.exclude.append(re.compile(line.strip()))

--- a/doc/demo.sh
+++ b/doc/demo.sh
@@ -4,7 +4,7 @@ cd $(dirname "$0")
 touch demo
 rm -rf demo
 mkdir demo
-cd demo
+pushd demo
 
 mkdir repo1
 cd repo1
@@ -44,7 +44,38 @@ cd ..
 
 git clone git@github.com:mnagel/clustergit clustergit-clean
 
+popd
+
+##
+# Demo multi-directory support
+##
+cd $(dirname "$0")
+touch demo2
+rm -rf demo2
+mkdir demo2
+pushd demo2
+
+mkdir repo1_in_demo2
+cd repo1_in_demo2
+git init
+cd ..
+
+mkdir repo2_in_demo2
+cd repo2_in_demo2
+git init
+git checkout --orphan otherbranch
+cd ..
+
+mkdir repo3_in_demo2
+cd repo3_in_demo2
+git init
+touch a b c
+git add .
+git commit -a -m "nevermind"
+cd ..
+
+popd
+
 ## now run
-# cd demo
-# clustergit --warn-unversioned
-# clustergit --pull
+# clustergit -d demo -d demo2 --warn-unversioned
+# clustergit -d demo -d demo2 --pull


### PR DESCRIPTION
Adding support for multiple directory input.

### Use case
I have several 'root' directories I would like `clustergit` to scan all in one invocation.

For example, say I have 3 directories I wish to use `clustergit` with; `~/dotfiles`, `~/GitHub`, and `~/work` - right now I would have to invoke:
```
./clustergit -d ~/dotfiles/
./clustergit -d ~/GitHub/
./clustergit -d ~/work/
```

**Instead**, I would like to simply invoke:
```
./clustergit -d ~/dotfiles/ -d ~/GitHub/ -d ~/work/
```

This change brings that capability. I updated the `demo.sh` script to have two 'root' directories which contain several git repos within; see "Tested Locally" section below for sample output.

### Tested locally
_(from within `clustergit/doc` directory after running `./demo.sh`...)_
```
$ > ../clustergit -d demo -d demo2 --warn-unversioned
Scanning sub directories of ['demo', 'demo2']
demo/norepo                             : Not a GIT repository
demo/arepo                              : Clean
demo/clustergit                         : No Changes, Unpushed commits
demo/clustergit-clean                   : Clean
demo/repo1                              : Changes
demo/repo2                              : On branch otherbranch, Changes
demo/repo3                              : Clean
demo2/repo1_in_demo2                    : Changes
demo2/repo2_in_demo2                    : On branch otherbranch, Changes
demo2/repo3_in_demo2                    : Clean
Done

$ > ../clustergit -d demo -d demo2 --pull
Scanning sub directories of ['demo', 'demo2']
demo/arepo                              : Clean, Pull remote not configured
demo/clustergit                         : No Changes, Unpushed commits
demo/clustergit-clean                   : Clean, Pulled
demo/repo1                              : Changes
demo/repo2                              : On branch otherbranch, Changes
demo/repo3                              : Clean, Pull remote not configured
demo2/repo1_in_demo2                    : Changes
demo2/repo2_in_demo2                    : On branch otherbranch, Changes
demo2/repo3_in_demo2                    : Clean, Pull remote not configured
Done
```