### PR TITLE
feat: add --skip-submodules argument

### DIFF
--- a/clustergit
+++ b/clustergit
@@ -258,6 +258,14 @@ def read_arguments(args: List[str]) -> argparse.Namespace:
     )
 
     parser.add_argument(
+        "--skip-submodules",
+        action="store_true",
+        dest="skip_submodules",
+        default=False,
+        help="Skip git submodules"
+    )
+
+    parser.add_argument(
         "-e", "--exclude",
         action="append",
         dest="exclude",
@@ -522,15 +530,21 @@ def scan(dirpath: str, dirnames: List[str], options: argparse.Namespace) -> List
                     print(f'skipping {path}')
                 return False
 
-        # Remove if is there a .clustergit-ignore file
+        # Remove if there is a .clustergit-ignore file
         if os.path.exists(os.path.join(path, ".clustergit-ignore")):
             if options.verbose:
                 print(f'skipping {path} directory')
             return False
 
-        # Remove if there is no .git dir
         if os.path.exists(os.path.join(path, ".git")):
+            if options.skip_submodules:
+                if os.path.isfile(os.path.join(path, ".git")):
+                    # Remove if there is a .git file (we are inside a git submodule)
+                    if options.verbose:
+                        print(f'skipping {path} git submodule')
+                    return False
             if options.skipSymLinks and os.path.islink(path):
+                # Remove if there is no .git dir
                 if options.verbose:
                     print(f'skipping {path} symbolic link')
                 return False

--- a/tests/tests/clustergit_test.py
+++ b/tests/tests/clustergit_test.py
@@ -17,12 +17,11 @@ class TestClustergit:
         clustergit.main([])
 
         actual_out = mystdout.getvalue()
-        expected_out = """Starting git status...
-Scanning sub directories of .
+        expected_out = """Scanning sub directories of ['.']
 
 """
         actual_err = mystderr.getvalue()
-        expected_err = """Error: None of those sub directories had a .git file.
+        expected_err = """Error: None of those sub directories had a .git file
 """
         same("stdout should be alright", expected_out, actual_out)
         same("stderr should be alright", expected_err, actual_err)

--- a/tests/tests/clustergit_test.py
+++ b/tests/tests/clustergit_test.py
@@ -1,6 +1,6 @@
-from tools import same
+from .tools import same
 
-from cStringIO import StringIO
+from io import StringIO
 import sys
 import tempfile
 
@@ -34,7 +34,7 @@ Scanning sub directories of .
 
     def test_check_fresh_repo(self):
         dirpath = tempfile.mkdtemp()
-        print "working in %s" % (dirpath)
+        print("working in %s" % (dirpath))
         clustergit.run('cd "%s"; mkdir mygit; cd mygit; git init' % (dirpath), clustergit.read_arguments(['-v']))
 
         old_stdout = sys.stdout
@@ -62,7 +62,7 @@ Done
 
     def test_excluded(self):
         dirpath = tempfile.mkdtemp()
-        print "working in %s" % (dirpath)
+        print("working in %s" % (dirpath))
         out = clustergit.run(
             'cd "%s";' % (dirpath)
             + 'mkdir notarepo repo1 repo2 target;'
@@ -71,7 +71,7 @@ Done
             + 'tree -A', # show structure in error messages
             clustergit.read_arguments(['-v'])
         )
-        print out
+        print(out)
 
         old_stdout = sys.stdout
         old_stderr = sys.stderr


### PR DESCRIPTION
One could argue that this should even be the default because the submodule is managed by containing repository. If the submodule is dirty, the containing repository is dirty as well. Plus the submodule might very well not be on a branch like master but on a specific git commit and that is fine.

But better not make it the default as it would change the behavior. When submodules annoy clustergit users, they can now use the --skip-submodules argument